### PR TITLE
Include the method name that wasn't found in the attribute error

### DIFF
--- a/jfx_bridge/bridge.py
+++ b/jfx_bridge/bridge.py
@@ -1111,7 +1111,7 @@ class BridgedClassMethod(object):
             remote_method = remote_type._bridged_get("__div__")
 
         if remote_method is None:
-            raise AttributeError()
+            raise AttributeError("Did not find %s method" % self.method_name)
 
         return functools.partial(remote_method, instance)
 


### PR DESCRIPTION
I ran into this while debugging code similar to:

```python
if currentProgram:
    pass
```
or
```python
x = currentProgram or "foobar"
```
This will try to access the `__len__` method and crash.

The fact that this crashes is most likely another issue entirely, but at least now it is clear what is happening, because getting an AttributeError in a line that doesn't obviously access an attribute is fairly confusing.