### PR TITLE
Fix possible infinite loop in read_exactly

### DIFF
--- a/jfx_bridge/bridge.py
+++ b/jfx_bridge/bridge.py
@@ -321,7 +321,7 @@ def read_exactly(sock, num_bytes):
     data = b""
     while num_bytes > 0:
         new_data = sock.recv(num_bytes)
-        if new_data is None:
+        if not new_data:
             # most likely reason for a none here is the socket being closed on the remote end
             raise BridgeClosedException()
         num_bytes = num_bytes - len(new_data)


### PR DESCRIPTION
https://docs.python.org/3/library/socket.html#socket.socket.recv
socket.recv returns empty byte string `b''` on failure not `None` meaning this error condition is never reached
